### PR TITLE
Add OpenOrca loader and distillation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # Qwen3-self-distillation
+
+This repository provides a minimal example of self-distilling the
+`Qwen/Qwen3-4B` model with the **Batch Method** described in the included
+excerpt. The teacher and student share the same architecture. The script
+`distill.py` loads the [OpenOrca](https://huggingface.co/datasets/Open-Orca/OpenOrca)
+dataset via the Hugging Face `datasets` library and performs one-step
+distillation while extracting the batch-wise denominator from the teacher
+outputs.
+
+```
+python distill.py
+```
+
+The example uses a streaming data loader and is meant as a starting point
+for experimenting with Batch Power‑Max and Batch Layer Normalization.


### PR DESCRIPTION
## Summary
- load OpenOrca dataset using the `datasets` library
- implement a streaming data loader
- update example to distill Qwen3-4B with itself on OpenOrca
- document usage in README

## Testing
- `python distill.py` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6846adc7c4e0832ea42f0c570d125210