### PR TITLE
Add remote code loading for Qwen3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # Qwen3-self-distillation
+
+This repository provides a minimal example of self-distilling the
+`Qwen/Qwen3-4B` model with the **Batch Method** described in the included
+excerpt. The teacher and student share the same architecture. The script
+`distill.py` loads the [OpenOrca](https://huggingface.co/datasets/Open-Orca/OpenOrca)
+dataset via the Hugging Face `datasets` library and performs one-step
+distillation while extracting the batch-wise denominator from the teacher
+outputs.
+
+```
+python distill.py
+```
+
+The script relies on `trust_remote_code=True` when loading the Qwen3 model
+because the architecture is not yet included in the released version of
+`transformers`. Ensure you have an up-to-date installation of
+`transformers` or install it from source.
+
+The example uses a streaming data loader and is meant as a starting point
+for experimenting with Batch Power‑Max and Batch Layer Normalization.

--- a/distill.py
+++ b/distill.py
@@ -1,5 +1,33 @@
 import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer
+from datasets import load_dataset
+
+
+def load_open_orca(batch_size: int = 1, split: str = "train"):
+    """Yield batches of text from the OpenOrca dataset.
+
+    Parameters
+    ----------
+    batch_size: int, optional
+        Number of samples to return per iteration.
+    split: str, optional
+        Dataset split to stream from.
+    """
+    dataset = load_dataset("Open-Orca/OpenOrca", split=split, streaming=True)
+
+    batch = []
+    for sample in dataset:
+        prompt = " ".join(
+            str(sample.get(key, ""))
+            for key in ["system_prompt", "question"]
+            if sample.get(key)
+        ).strip()
+        batch.append(prompt)
+        if len(batch) == batch_size:
+            yield list(batch)
+            batch.clear()
+    if batch:
+        yield list(batch)
 
 
 def extract_denominator(outputs, p: float = 2.0, c: float = 0.0) -> torch.Tensor:
@@ -28,10 +56,16 @@ def extract_denominator(outputs, p: float = 2.0, c: float = 0.0) -> torch.Tensor
 def distill(teacher_name: str, student_name: str, data_loader):
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
-    teacher = AutoModelForCausalLM.from_pretrained(teacher_name).to(device)
-    tokenizer = AutoTokenizer.from_pretrained(teacher_name)
+    teacher = AutoModelForCausalLM.from_pretrained(
+        teacher_name, trust_remote_code=True
+    ).to(device)
+    tokenizer = AutoTokenizer.from_pretrained(
+        teacher_name, trust_remote_code=True
+    )
 
-    student = AutoModelForCausalLM.from_pretrained(student_name).to(device)
+    student = AutoModelForCausalLM.from_pretrained(
+        student_name, trust_remote_code=True
+    ).to(device)
 
     optimizer = torch.optim.AdamW(student.parameters(), lr=5e-5)
 
@@ -59,6 +93,6 @@ def distill(teacher_name: str, student_name: str, data_loader):
 
 
 if __name__ == "__main__":
-    # Example usage with dummy data
-    dummy_data = ["Hello world"]
-    distill("Qwen/Qwen3-4B", "Qwen/Qwen3-4B", dummy_data)
+    # Distil the Qwen3-4B model with itself using the OpenOrca dataset.
+    loader = load_open_orca(batch_size=2, split="train")
+    distill("Qwen/Qwen3-4B", "Qwen/Qwen3-4B", loader)


### PR DESCRIPTION
## Summary
- load Qwen3 with `trust_remote_code=True`
- document need for up-to-date `transformers`

## Testing
- `python distill.py` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6846adc7c4e0832ea42f0c570d125210