### PR TITLE
Add transformers version check

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,12 @@ python distill.py
 
 The example uses a streaming data loader and is meant as a starting point
 for experimenting with Batch Power‑Max and Batch Layer Normalization.
+
+## Requirements
+
+This example requires `transformers>=4.40.0` to load the Qwen3 model.
+If you encounter errors about `ALL_PARALLEL_STYLES`, upgrade transformers:
+
+```bash
+pip install --upgrade transformers
+```

--- a/distill.py
+++ b/distill.py
@@ -1,5 +1,14 @@
 import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer
+import transformers
+from packaging import version
+
+REQUIRED_TRANSFORMERS = "4.40.0"
+
+if version.parse(transformers.__version__) < version.parse(REQUIRED_TRANSFORMERS):
+    raise RuntimeError(
+        f"transformers>={REQUIRED_TRANSFORMERS} is required, got {transformers.__version__}."
+    )
 from datasets import load_dataset
 
 


### PR DESCRIPTION
## Summary
- ensure the installed `transformers` package is up to date by checking for
  version 4.40.0 or later
- document the requirement in the README

## Testing
- `python distill.py` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6846c96b04b4832e8f31efb5b042d25d