### PR TITLE
Train lm_head only with Batch Power‑Max

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # Qwen3-self-distillation
 
-This repository provides a minimal example of self-distilling the
+This repository provides a minimal example of self‑distilling the
 `Qwen/Qwen3-4B` model with the **Batch Method** described in the included
 excerpt. The teacher and student share the same architecture. The script
 `distill.py` loads the [OpenOrca](https://huggingface.co/datasets/Open-Orca/OpenOrca)
 dataset via the Hugging Face `datasets` library and performs one-step
-distillation while extracting the batch-wise denominator from the teacher
-outputs.
+distillation. Only the student's final ``lm_head`` is trained and the
+Batch Power‑Max transformation is used in place of softmax. During
+training the batch-wide denominator ``R_d`` is recorded and saved to
+``rd_value.pt`` for use during inference.
 
 ```
 python distill.py


### PR DESCRIPTION
## Summary
- freeze all student parameters except `lm_head`
- implement Batch Power‑Max transformation
- train with BPMax and record the batch denominator `R_d`
- document new behaviour in README

## Testing
- `python -m py_compile distill.py`


------
https://chatgpt.com/codex/tasks/task_e_68485dcc1874832ea845e6cac541ba9a